### PR TITLE
Allowing a simple fallback for the solution of degenerate Eikonal equations

### DIFF
--- a/CPPLINT.cfg
+++ b/CPPLINT.cfg
@@ -3,3 +3,6 @@ filter=-build/c++11
 
 # Allow for non-const reference parameters
 filter=-runtime/references
+
+# Disable "Missing username in TODO" warning
+filter=-readability/todo

--- a/examples/python/py-fast-marching-minimal-example.py
+++ b/examples/python/py-fast-marching-minimal-example.py
@@ -4,10 +4,10 @@ import matplotlib.pyplot as plt
 
 
 def signed_arrival_time_example():
-    grid_size = np.array([101, 101])
+    grid_size = np.array([50, 100])
     # grid_spacing = 1.0 / grid_size
     grid_spacing = np.ones(grid_size.shape)
-    boundary_indices = np.array([[50, 50]])
+    boundary_indices = np.array([[31, 75]])
     boundary_times = np.array([0.0])
     uniform_speed = 1.0
 
@@ -18,6 +18,7 @@ def signed_arrival_time_example():
     print("Max dist:", np.max(arrival_times[:]))
 
     plt.imshow(arrival_times)
+    plt.plot(boundary_indices[0,1], boundary_indices[0,0], "mo")
     plt.colorbar()
     plt.show()
 

--- a/include/thinks/fast_marching_method/fast_marching_method.hpp
+++ b/include/thinks/fast_marching_method/fast_marching_method.hpp
@@ -1545,6 +1545,8 @@ T SolveEikonal(std::array<std::int32_t, N> const& index,
     if (use_eikonal_fallback && !(arrival_time >= T{0})) {
       // In case the discriminant is negative, we revert to the smallest
       // distance to a single neighbor
+      // TODO if dimension N>=3 we could try to find the smallest dimension
+      // for the Eikonal equations in dimension N-1
       auto distance = frozen_neighbor_distances[0].first;
       auto j = frozen_neighbor_distances[0].second;
       arrival_time = distance + grid_spacing[j] / speed;
@@ -1689,6 +1691,8 @@ T HighAccuracySolveEikonal(std::array<std::int32_t, N> const& index,
     if (use_eikonal_fallback && !(arrival_time >= T{0})) {
       // In case the discriminant is negative, we revert to the smallest
       // distance to a single neighbor
+      // TODO if dimension N>=3 we could try to find the smallest dimension
+      // for the Eikonal equations in dimension N-1
       auto distance = frozen_neighbor_distances[0].first.first;
       auto j = frozen_neighbor_distances[0].second;
       arrival_time = distance + grid_spacing[j] / speed;

--- a/tests/py-bindings-test.py
+++ b/tests/py-bindings-test.py
@@ -4,10 +4,10 @@ from scipy import ndimage as ndi
 
 
 def test_uniform_2D():
-    grid_size = np.array([101, 101])
+    grid_size = np.array([50, 101])
     # grid_spacing = 1.0/grid_size
     grid_spacing = np.ones(grid_size.shape)
-    boundary_indices = np.array([[50, 50]])
+    boundary_indices = np.array([[20, 75]])
     boundary_times = np.array([0.0])
     uniform_speed = 1.0
 
@@ -30,10 +30,10 @@ def test_uniform_2D():
 
 
 def test_uniform_3D():
-    grid_size = np.array([101, 101, 101])
+    grid_size = np.array([30, 76, 43])
     # grid_spacing = 1.0/grid_size
     grid_spacing = np.ones(grid_size.shape)
-    boundary_indices = np.array([[50, 50, 50]])
+    boundary_indices = np.array([[9, 50, 21]])
     boundary_times = np.array([0.0])
     uniform_speed = 1.0
 
@@ -58,10 +58,10 @@ def test_uniform_3D():
 
 
 def test_varying_2D():
-    grid_size = np.array([5, 5])
+    grid_size = np.array([5, 8])
     # grid_spacing = 1.0/grid_size
     grid_spacing = np.ones(grid_size.shape)
-    boundary_indices = np.array([[2, 2]])
+    boundary_indices = np.array([[2, 5]])
     boundary_times = np.array([0.0])
     varying_speed = np.ones(grid_size)
 

--- a/tests/signed_arrival_time_test.cpp
+++ b/tests/signed_arrival_time_test.cpp
@@ -303,7 +303,8 @@ TYPED_TEST(SignedArrivalTimeTest, EikonalSolverFailThrows) {
   typedef typename TypeParam::ScalarType ScalarType;
   static constexpr std::size_t kDimension = TypeParam::kDimension;
   namespace fmm = thinks::fast_marching_method;
-  typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension>
+  // Test if eikonal solver fails when no fallback is requested
+  typedef fmm::UniformSpeedEikonalSolver<ScalarType, kDimension, false>
       EikonalSolverType;
 
   // Arrange.
@@ -600,7 +601,7 @@ TYPED_TEST(SignedArrivalTimeTest, Checkerboard) {
 
   auto const is_even = [](auto const i) { return i % 2 == 0; };
   auto const is_boundary = [=](auto const index) {
-    return is_even( std::reduce(begin(index), end(index)) );
+    return is_even(std::reduce(begin(index), end(index)));
   };
 
   auto boundary_indices = std::vector<std::array<int32_t, kDimension>>();


### PR DESCRIPTION
As discussed on [wikipedia](https://en.wikipedia.org/wiki/Eikonal_equation#n-D_approximation_on_a_Cartesian_grid), if the discriminant in the square root of the Eikonal equation is negative, then a lower-dimensional update must be performed.

For now, a fallback to a one-dimensional update has been implemented. Future improvement should consider reducing the dimension 1 by 1 if N>=3.